### PR TITLE
Add basic testthat setup

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,3 @@
+library(testthat)
+
+test_dir("tests/testthat")

--- a/tests/testthat/test-alfred.R
+++ b/tests/testthat/test-alfred.R
@@ -1,0 +1,25 @@
+library(testthat)
+
+# Helper to load functions without executing setup or cleanup
+load_alfred_functions <- function() {
+  code <- readLines("alfred.r")[1:87]
+  eval(parse(text = code), envir = globalenv())
+}
+
+test_that("build_query_functions creates functions", {
+  load_alfred_functions()
+  build_query_functions(list(sample_call = c("id")))
+  expect_true(exists("sample_call", envir = fred))
+  expect_true(is.function(fred$sample_call))
+  rm(fred, schema, build_query_functions, .parse_args, .url, .read_fred, set_api_key, sample_call, pos = globalenv())
+})
+
+test_that("API call returns expected structure", {
+  load_alfred_functions()
+  build_query_functions(list(sample_call = c("id")))
+  sample_output <- list(result = "ok")
+  assign(".read_fred", function(call, simplify_df = FALSE) sample_output, envir = globalenv())
+  out <- fred$sample_call(id = 1)
+  expect_equal(out, sample_output)
+  rm(fred, schema, build_query_functions, .parse_args, .url, .read_fred, set_api_key, sample_call, pos = globalenv())
+})


### PR DESCRIPTION
## Summary
- create `tests/testthat` and configure test runner
- add tests for `build_query_functions` and mocked API calls

## Testing
- `Rscript tests/testthat.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f57e26248327a8a09c3301f0278c