### PR TITLE
Add load_api_key function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ wrap in more streamlined functions.
 
 Note that I put this script together in a hurry. It works well for me,
 but has not been thoroughly tested. If you find any bugs, please let me know.
+
+## API Key
+
+API requests require a FRED API key. Use `load_api_key()` to initialise the
+package. The function first checks the `FRED_API_KEY` environment variable and
+then the file `~/.fred_api_key`. When called interactively, it will prompt for a
+key if one was not found and save it to that file for future sessions.

--- a/alfred.r
+++ b/alfred.r
@@ -50,6 +50,27 @@ set_api_key <- \(api_key) {
   .api_key <<- api_key
 }
 
+# load api key from environment, file or user prompt                 [user facing]
+load_api_key <- \(
+    env_var = "FRED_API_KEY",
+    file = "~/.fred_api_key",
+    prompt = interactive()) {
+  key <- Sys.getenv(env_var, unset = "")
+  if (!nzchar(key) && file.exists(path.expand(file))) {
+    key <- readLines(path.expand(file), warn = FALSE)[1]
+  }
+  if (!nzchar(key) && isTRUE(prompt)) {
+    cat("Enter FRED API key: ")
+    key <- readline()
+    if (nzchar(key)) {
+      dir.create(dirname(path.expand(file)), showWarnings = FALSE, recursive = TRUE)
+      writeLines(key, path.expand(file))
+    }
+  }
+  if (nzchar(key)) set_api_key(key) else warning("FRED API key not found")
+  invisible(key)
+}
+
 # --- FRED API OPTIONS ------------------------------------------------------- #
 schema <- list(
   category = c('category_id'),
@@ -86,7 +107,7 @@ schema <- list(
 )
 
 # --- UI SETUP --------------------------------------------------------------- #
-set_api_key(Sys.getenv("FRED_API_KEY"))
+load_api_key()
 build_query_functions(schema) # build all 31 api call functions
 
 attach(fred)


### PR DESCRIPTION
## Summary
- add a helper to load the API key from env var, config file or user prompt
- document API key loading in the README
- use `load_api_key()` during setup

## Testing
- `Rscript -e "source('alfred.r'); cat('functions loaded\n'); print('api loaded');"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f5b22000832790b515d7670f8d04