### PR TITLE
Add R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -1,0 +1,27 @@
+name: R-CMD-check
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("httr2", "testthat"), repos = "https://cloud.r-project.org")
+        shell: Rscript {0}
+
+      - name: Run tests
+        run: |
+          testthat::test_dir("tests/testthat")
+        shell: Rscript {0}


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run `Rscript` tests on pushes and PRs

## Testing
- `Rscript tests/testthat.R` *(fails: cannot open the connection)*

------
https://chatgpt.com/codex/tasks/task_e_68430117de0c83278fc09231d71b08da